### PR TITLE
field fixes

### DIFF
--- a/action/action.cpp
+++ b/action/action.cpp
@@ -11,8 +11,7 @@ void Action::move_left(Creature* creature, float time, const Field& game_field) 
     auto& current_frame = creature->get_frame();
     current_frame += 0.15f * time;
     auto& pos = creature->get_pos();
-    if (game_field(pos.y / 32 + 1, (pos.x - time) / 32 + 1).get_passability())
-        pos.x -= time;
+    pos.x -= time * game_field(pos.y / 32 + 1, (pos.x - time) / 32 + 1).get_passability() / 2.0;
     if (current_frame > 8) current_frame = 0;
     creature->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
     creature->get_sprite().setTextureRect(sf::IntRect(((int)current_frame + 1) * 64, 64, 64, 64));
@@ -33,8 +32,7 @@ void Action::move_right(Creature* creature, float time, const Field& game_field)
     auto& current_frame = creature->get_frame();
     current_frame += 0.15f * time;
     auto& pos = creature->get_pos();
-    if ((game_field(pos.y / 32 + 1, (pos.x + time) / 32 + 1).get_passability()))
-        pos.x += time;
+    pos.x += time * game_field(pos.y / 32 + 1, (pos.x + time) / 32 + 1).get_passability() / 2.0;
     if (current_frame > 8) current_frame = 0;
     creature->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
     creature->get_sprite().setTextureRect(sf::IntRect(((int)current_frame + 1) * 64, 192, 64, 64));
@@ -55,8 +53,7 @@ void Action::move_up(Creature* creature, float time, const Field& game_field) {
     auto& current_frame = creature->get_frame();
     current_frame += 0.15f * time;
     auto& pos = creature->get_pos();
-    if ((game_field((pos.y - time) / 32 + 1, pos.x / 32 + 1).get_passability()))
-        pos.y -= time;
+    pos.y -= time * game_field((pos.y - time) / 32 + 1, pos.x / 32 + 1).get_passability() / 2.0;
     if (current_frame > 8) current_frame = 0;
     creature->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
     creature->get_sprite().setTextureRect(sf::IntRect(((int)current_frame + 1) * 64, 0, 64, 64));
@@ -76,10 +73,8 @@ void Action::move_up(Creature* creature, float time, const Field& game_field) {
 void Action::move_down(Creature* creature, float time, const Field& game_field) {
     auto& current_frame = creature->get_frame();
     current_frame += 0.15f * time;
-    current_frame += 0.15f * time;
     auto& pos = creature->get_pos();
-    if ((game_field((pos.y + time) / 32 + 1, pos.x / 32 + 1).get_passability()))
-        pos.y += time;
+    pos.y += time * game_field((pos.y + time) / 32 + 1, pos.x / 32 + 1).get_passability() / 2.0;
     if (current_frame > 8) current_frame = 0;
     creature->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
     creature->get_sprite().setTextureRect(sf::IntRect(((int)current_frame + 1) * 64, 128, 64, 64));

--- a/field/field.h
+++ b/field/field.h
@@ -9,7 +9,7 @@ class Field
 private:
     int _width;
     int _height;
-    std::vector <std::vector<Tile*>> _field;
+    std::vector <std::vector<std::shared_ptr<Tile>>> _field;
     
 public:
     // constructors~destructor
@@ -17,7 +17,7 @@ public:
     Field(int w, int h);
     Field(Field&&);
     Field(const Field&) = delete;
-    ~Field();
+    ~Field(){}
     
     // operators
     Field& operator=(Field&&);

--- a/tests/tiles_test.cpp
+++ b/tests/tiles_test.cpp
@@ -15,11 +15,10 @@ void test1() {
     load_textures_t();
     auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
     for (int i = 0; i < 3; ++i) {
-        Tile desert1 = *Tile::make_tile(TilesType::DESERT, HOLDER().getResource("sand1"));
-        Tile desert2 = *Tile::make_tile(TilesType::DESERT, HOLDER().getResource("borders_sand1"));
-        Tile desert3 = *Tile::make_tile(TilesType::DESERT, HOLDER().getResource("oasis1"));
-        Tile grass = *Tile::make_tile(TilesType::GRASS, HOLDER().getResource("grass1"));
-        Tile water = *Tile::make_tile(TilesType::WATER, HOLDER().getResource("water1"));
+        Tile desert1 = *Tile::make_tile(TilesType::DESERT1_SAND, i, i);
+        Tile desert2 = *Tile::make_tile(TilesType::DESERT1_BORDERS, i, i);
+        Tile desert3 = *Tile::make_tile(TilesType::DESERT1_OASIS, i, i);
+        Tile grass = *Tile::make_tile(TilesType::DESERT1_CRACKS, i, i);
     }
 }
 
@@ -29,14 +28,14 @@ TEST(Tile, factory_check_values) {
 
 TEST(Tile, equality) {
     auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
-    Tile desert1 = *Tile::make_tile(TilesType::DESERT, HOLDER().getResource("sand1"));
-    Tile desert2 = *Tile::make_tile(TilesType::DESERT, HOLDER().getResource("sand1"));
+    Tile desert1 = *Tile::make_tile(TilesType::DESERT1_SAND, 0, 0);
+    Tile desert2 = *Tile::make_tile(TilesType::DESERT1_SAND, 0, 0);
     ASSERT_EQ(desert1, desert2);
 }
 
 TEST(Tile, no_equality) {
     auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
-    Tile grass = *Tile::make_tile(TilesType::GRASS, HOLDER().getResource("grass1"));
-    Tile river = *Tile::make_tile(TilesType::WATER, HOLDER().getResource("water1"));
+    Tile grass = *Tile::make_tile(TilesType::DESERT1_BORDERS, 0, 0);
+    Tile river = *Tile::make_tile(TilesType::DESERT1_CRACKS, 0, 0);
     ASSERT_NE(grass, river);
 }

--- a/tiles/DesertTile/DesertTile.cpp
+++ b/tiles/DesertTile/DesertTile.cpp
@@ -1,7 +1,41 @@
 #include "DesertTile.h"
 
-DesertTile::DesertTile(const sf::Texture* texture) {
-	_type = TilesType::DESERT;
-	_texture = texture;
+Desert1_sand::Desert1_sand(int i, int j) {
+	auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
+	_type = TilesType::DESERT1_SAND;
+	_texture = HOLDER().getResource("sand1");
 	_sprite.setTexture(*_texture);
+	scale(i, j);
+	_sprite.move(sf::Vector2f(j * 32, i * 32));
+	_passability = 2;
+}
+
+Desert1_borders::Desert1_borders(int i, int j, int r_borter, int btm_border) {
+	auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
+	_type = TilesType::DESERT1_BORDERS;
+	_texture = HOLDER().getResource("borders_sand1");
+	_sprite.setTexture(*_texture);
+	scale_borders(i, j, r_borter, btm_border);
+	_sprite.move(sf::Vector2f(j * 32, i * 32));
+	_passability = 0;
+}
+
+Desert1_oasis::Desert1_oasis(int i, int j) {
+	auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
+	_type = TilesType::DESERT1_OASIS;
+	_texture = HOLDER().getResource("oasis1");
+	_sprite.setTexture(*_texture);
+	scale(i, j);
+	_sprite.move(sf::Vector2f(j * 32, i * 32));
+	_passability = 0;
+}
+
+Desert1_cracks::Desert1_cracks(int i, int j) {
+	auto HOLDER = getGlobalResourceHolder<sf::Texture, std::string>;
+	_type = TilesType::DESERT1_CRACKS;
+	_texture = HOLDER().getResource("dry1");
+	_sprite.setTexture(*_texture);
+	scale(i, j);
+	_sprite.move(sf::Vector2f(j * 32, i * 32));
+	_passability = 2;
 }

--- a/tiles/DesertTile/DesertTile.h
+++ b/tiles/DesertTile/DesertTile.h
@@ -1,7 +1,22 @@
 #pragma once
 #include "../tiles.h"
 
-class DesertTile : public Tile {
+class Desert1_sand : public Tile {
 public:
-	DesertTile(const sf::Texture* texture);
+	Desert1_sand(int i, int j);
+};
+
+class Desert1_borders : public Tile {
+public:
+	Desert1_borders(int i, int j, int r_borter, int btm_border);
+};
+
+class Desert1_oasis : public Tile {
+public:
+	Desert1_oasis(int i, int j);
+};
+
+class Desert1_cracks : public Tile {
+public:
+	Desert1_cracks(int i, int j);
 };

--- a/tiles/tiles.cpp
+++ b/tiles/tiles.cpp
@@ -6,7 +6,7 @@
 
 Tile::Tile()
 {
-    _passability = true;
+    _passability = 2;
     _texture = nullptr;
 }
 
@@ -14,12 +14,16 @@ Tile::~Tile() {
     _texture = nullptr;
 }
 
-Tile* Tile::make_tile(TilesType type, const sf::Texture* txt) {
+std::shared_ptr<Tile> Tile::make_tile(TilesType type, int i, int j, int r_b, int b_b) {
     switch (type) {
-    case TilesType::GRASS: return new GrassTile(txt);
-    case TilesType::WATER: return new WaterTile(txt);
-    case TilesType::DESERT: return new DesertTile(txt);
-    case TilesType::ROAD: return new RoadTile(txt);
+    case TilesType::DESERT1_SAND: return std::make_shared<Tile>(*(new Desert1_sand(i, j)));
+    case TilesType::DESERT1_BORDERS: return std::make_shared<Tile>(*(new Desert1_borders(i, j, r_b, b_b)));
+    case TilesType::DESERT1_OASIS: return std::make_shared<Tile>(*(new Desert1_oasis(i, j)));
+    case TilesType::DESERT1_CRACKS: return std::make_shared<Tile>(*(new Desert1_cracks(i, j)));
+
+    /*case TilesType::GRASS: return std::make_shared<Tile>(*(new GrassTile));
+    case TilesType::WATER: return std::make_shared<Tile>(*(new WaterTile));
+    case TilesType::ROAD: return std::make_shared<Tile>(*(new RoadTile));*/
     default: return nullptr;
     }
 }

--- a/tiles/tiles.h
+++ b/tiles/tiles.h
@@ -17,15 +17,24 @@
 
 enum class TilesType {
     NONE,
-    WATER,
+
+    // grassland tiles
     GRASS,
-    DESERT,
+
+    // desert tiles
+    DESERT1_SAND,
+    DESERT1_OASIS,
+    DESERT1_BORDERS,
+    DESERT1_CRACKS,
+
+    // univerasl tiles
+    WATER,
     ROAD
 };
 
 class Tile {
 protected:
-    bool _passability;
+    int _passability;
     const sf::Texture* _texture;
     sf::Sprite _sprite;
     const sf::Texture* _feature_texture;
@@ -43,15 +52,14 @@ public:
     bool operator!=(const Tile& tile) const;
 
     //methods
-    static Tile* make_tile(TilesType type, const sf::Texture*);
+    static std::shared_ptr<Tile> make_tile(TilesType type, int i, int j, int r_b = 128, int b_b = 128);
     sf::Sprite print_tile() const { return _sprite; }
     sf::Sprite print_feature() const { return _feature_sprite; }
     void scale(int i, int j);
     void scale_borders(int i, int j, int r_b, int btm_b);
 
     // getters & setters
-    bool get_passability() { return _passability; }
-    void set_passability(bool f) { _passability = f; }
+    int get_passability() { return _passability; }
     void set_desert_feature(const sf::Texture*, int);
     sf::Sprite& get_sprite() { return _sprite; }
     sf::Sprite& get_feature() { return _feature_sprite; }


### PR DESCRIPTION
Rewrote the field with shared_ptr (generation longer by 10 ms (0.085s))
Texturing the field immediately (generation 0.080s)
Clearer differentiation of desert tiles (sand, border, oasis, cracks etc)
Reworked the method of creating tiles (FINAL TIME generation 0.075s)
Reworked the mechanics of passability of tiles (now there are 3 modes: passable(2),
difficult to pass(1) (speed is reduced by 2 times), impassable(0))
Minor edits (removed some unnecessary methods, changed tiles_tests)

Additionally:
In the move_down function, removed an extra line that doubled the animation speed